### PR TITLE
fix: possible fix for device statistics (e.g. S23+ URL encoding problem)

### DIFF
--- a/src/app/modules/statistics/screens/statistics-screen/statistics-screen.component.ts
+++ b/src/app/modules/statistics/screens/statistics-screen/statistics-screen.component.ts
@@ -235,7 +235,7 @@ export class StatisticsScreenComponent extends SeoComponent implements OnInit {
             duration,
             end_date,
           } = this.store.filters
-          let params = `pinned=true&model=${device.model}`
+          let params = `pinned=true&model=${encodeURIComponent(device.model)}`
           if (type == "mobile") {
             params += `&mobile_provider_name=*`
             if (


### PR DESCRIPTION
Statistics for device S23+ currently broken because "+" is not correctly URL encoded (%2B):
https://www.netztest.at/en/opentests?loc_accuracy%5B%5D=%3E0&loc_accuracy%5B%5D=%3C2000&model=Galaxy%20S23%20&time%5B%5D=%3E2024-01-31%2023:00:00&time%5B%5D=%3C2025-11-03%2014:12:39&country_geoip=at&pinned=true