### PR TITLE
Fix incorrect URL format for Google Play Store link in options.en.html

### DIFF
--- a/src/assets/html/options/options.en.html
+++ b/src/assets/html/options/options.en.html
@@ -20,7 +20,7 @@
 <p>
   The Android-App can be downloaded using the
   <a
-    href="/https://play.google.com/store/apps/details?id=at.alladin.rmbt.android"
+    href="https://play.google.com/store/apps/details?id=at.alladin.rmbt.android"
     target="_blank"
     title="Download RTR-Netztest"
     >Google Play Store</a


### PR DESCRIPTION
Removed a leading slash (`/`) from the Play Store `href`.

Previously, the link was treated as a relative path, resolving to `https://www.netztest.at/https://....` This change ensures it links directly to the external Google Play URL.